### PR TITLE
Comply with strict mode

### DIFF
--- a/lib/lowpass-comb-filter.js
+++ b/lib/lowpass-comb-filter.js
@@ -5,7 +5,7 @@ module.exports = LowpassCombFilter
 function LowpassCombFilter (context) {
   var node = context.createDelay(1)
 
-  var output = this.output = context.createBiquadFilter()
+  var output = context.createBiquadFilter()
 
   // this magic number seems to fix everything in Chrome 53
   // see https://github.com/livejs/freeverb/issues/1#issuecomment-249080213


### PR DESCRIPTION
Hello @mmckegg, I encountered this JS error when using your package: 
```
Cannot read property 'output' of undefined
```
Took me a while to understand that it is due to the `strict mode` (set globally in my app). AFAIK `use strict` is very common in JS and I don't see any reason to have this assignment. When running `example.js`, `this === window`. So maybe we can't remove it 🤔 