### PR TITLE
Disconnect output instead of input

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ function Freeverb (audioContext) {
   refreshFilters()
 
   node.connect = output.connect.bind(output)
+  node.disconnect = output.disconnect.bind(output)
   node.wet = wet.gain
   node.dry = dry.gain
 


### PR DESCRIPTION
Hello @mmckegg, I am encountering a new issue with Freeverb. I can't seem to disconnect and reconnect a Freeverb node. I think the `disconnect` method must be overridden so it disconnects the output gain instead of the input gain.